### PR TITLE
Make osrm url global config

### DIFF
--- a/surveyscout/__init__.py
+++ b/surveyscout/__init__.py
@@ -1,1 +1,5 @@
+from typing import Optional
+
 __version__ = "0.0.1"
+
+OSRM_URL: Optional[str] = None

--- a/surveyscout/config.py
+++ b/surveyscout/config.py
@@ -1,3 +1,0 @@
-import os
-
-OSRM_URL = os.environ.get("OSRM_URL", "http://localhost:5001")


### PR DESCRIPTION
Reviewer: @lickem22 

Estimate: 15 min

---

## Ticket

Fixes: -

## Description

### Goal

Relying solely on environment variables for setting library-level configuration can be brittle.

We need a way to set the `OSRM_URL` config at different points.

### Changes

1. `OSRM_URL` can be set at the library level 
    
    ```python
    import surveyscout

    surveyscout.OSRM_URL = "https://custom.osrmapi.com"
    ```

3. It can also be passed to the `get_enum_target_osrm_matrix` function directly

### Future Tasks (optional)

- [ ] Modify #8  to accept optional `osrm_url` parameter

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)